### PR TITLE
Gradebook final

### DIFF
--- a/API/Enrollment.php
+++ b/API/Enrollment.php
@@ -561,7 +561,7 @@ function getSectionEnrolled($sectionID)
 		$sqlite->enableExceptions(true);
 		
 		//prepare query to protect from sql injection
-		$query = $sqlite->prepare("SELECT STUDENT_ID FROM Student_Section WHERE SECTION_ID=:sectionID");
+		$query = $sqlite->prepare("SELECT ID, STUDENT_ID FROM Student_Section WHERE SECTION_ID=:sectionID");
 		$query->bindParam(':sectionID', $sectionID);
 		$result = $query->execute();
 		


### PR DESCRIPTION
The final requests of Gradebook team API calls.

From @ZacharyMoran / Enrollment team: As discussed, we'd like that the ID of the student section be returned from the `getSectionEnrolled` call.

We add two more functions to the grading API for retrieving notifications for a given student section and marking a notification as expired.